### PR TITLE
Fixed unknown property: charset

### DIFF
--- a/src/Rah/Danpu/Export.php
+++ b/src/Rah/Danpu/Export.php
@@ -111,7 +111,7 @@ class Export extends Base
         if ($this->config->createDatabase === true) {
             $this->write(
                 'CREATE DATABASE IF NOT EXISTS `'.$this->database.'` '.
-                'DEFAULT CHARACTER SET = '.$this->escape($this->config->charset)
+                'DEFAULT CHARACTER SET = '.$this->escape($this->config->encoding)
             );
             $this->write('USE `'.$this->database.'`');
         }


### PR DESCRIPTION
When adding the option `createDatabase()` dumping failed due to `unknown property: charset`. It should look for `encoding` instead.
