### PR TITLE
Add support for better excaping of different MySQL data types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.coveralls.yml
 /composer.lock
 /phpunit.xml
+/.idea
+/console


### PR DESCRIPTION
I made this change because Export made all integer data for ENUM unescapated. And this means position of value in ENUM definition and not a data.

Example:
  columnname enum('0', '1', '2') ...

  insert into tablename (columnname) value (0) ... means error, becouse 0 here is integer and MySQL means, it is position 0 in ENUM, but positions in ENUM are indexed from 1.
Right:
  insert into tablename (columnname) value ('0') ...
